### PR TITLE
modules: Kconfig.nordic: Elevate 802.15.4 serialized radio init priority

### DIFF
--- a/modules/Kconfig.nordic
+++ b/modules/Kconfig.nordic
@@ -126,7 +126,7 @@ if NRF_802154_SER_RADIO
 
 config NRF_802154_SER_RADIO_INIT_PRIO
 	int "nRF52 IEEE 802.15.4 serialization initialization priority"
-	default 81
+	default 47
 	help
 	  Set the initialization priority number. Do not mess with it unless
 	  you know what you are doing.


### PR DESCRIPTION
Signed-off-by: Jedrzej Ciupis <jedrzej.ciupis@nordicsemi.no>